### PR TITLE
Fix file path len

### DIFF
--- a/Mail_downloader.py
+++ b/Mail_downloader.py
@@ -37,7 +37,6 @@ MailBox_folder_list = ""
 now = time.time()
 errorcounter = 0
 
-
 def zipfolder(foldername):
     if errorcounter >= 1:
         foldername = f"{foldername}_haserrors"
@@ -82,6 +81,10 @@ with MailBox(imap_server, port=imap_port).login_utf8(
                             print(Foldername)
 
                     MailBox.folder.set(Foldername)
+                    
+                    base_dir = os.path.abspath(f"export/{imap_server}/{Foldername}")
+                    max_filename_len = 259 - len(base_dir) - 10  # 10 = buffer für \, .eml, safety
+
                     for msg in MailBox.fetch(mark_seen=False):
                         uid = msg.uid
                         invalid_char = [
@@ -110,8 +113,8 @@ with MailBox(imap_server, port=imap_port).login_utf8(
 
                         filename = f"{uid}_{Mail_Subject}"
 
-                        if len(filename) > 250:
-                            filename = f"{filename[:250]}"
+                        if len(filename) > max_filename_len:
+                            filename = f"{filename[:max_filename_len]}"
 
                         FilePath = f"export/{imap_server}/{Foldername}/{filename}.eml"
 

--- a/Mail_downloader.py
+++ b/Mail_downloader.py
@@ -86,44 +86,57 @@ with MailBox(imap_server, port=imap_port).login_utf8(
                     max_filename_len = 259 - len(base_dir) - 10  # 10 = buffer für \, .eml, safety
 
                     for msg in MailBox.fetch(mark_seen=False):
-                        uid = msg.uid
-                        invalid_char = [
-                            ":",
-                            "“",
-                            "\r\n",
-                            "„",
-                            '"',
-                            "!",
-                            "?",
-                            "/",
-                            "\\",
-                            "*",
-                            "<",
-                            ">",
-                            "|",
-                            "ß",
-                            "\t",
-                            "\r",
-                            "\n",
-                        ]
+                        try:
 
-                        Mail_Subject = msg.subject
-                        for char in invalid_char:
-                            Mail_Subject = Mail_Subject.replace(char, "_")
+                            uid = msg.uid
+                            invalid_char = [
+                                ":",
+                                "“",
+                                "\r\n",
+                                "„",
+                                '"',
+                                "!",
+                                "?",
+                                "/",
+                                "\\",
+                                "*",
+                                "<",
+                                ">",
+                                "|",
+                                "ß",
+                                "\t",
+                                "\r",
+                                "\n",
+                            ]
 
-                        filename = f"{uid}_{Mail_Subject}"
+                            Mail_Subject = msg.subject
+                            for char in invalid_char:
+                                Mail_Subject = Mail_Subject.replace(char, "_")
 
-                        if len(filename) > max_filename_len:
-                            filename = f"{filename[:max_filename_len]}"
+                            filename = f"{uid}_{Mail_Subject}"
 
-                        FilePath = f"export/{imap_server}/{Foldername}/{filename}.eml"
+                            if len(filename) > max_filename_len:
+                                filename = f"{filename[:max_filename_len]}"
 
-                        if not os.path.exists(FilePath):
-                            raw_email = msg.obj
-                            print(FilePath)
-                            with open(FilePath, "w", encoding="utf-8") as g:
+                            FilePath = f"export/{imap_server}/{Foldername}/{filename}.eml"
+
+                            if not os.path.exists(FilePath):
+                                raw_email = msg.obj
+                                print(FilePath)
+                                with open(FilePath, "w", encoding="utf-8") as g:
+                                    with redirect_stdout(g):
+                                        print(raw_email)
+
+                        except Exception as error:
+                            with open(f"export/{imap_server}/Error.log", "a", encoding="utf-8") as g:
                                 with redirect_stdout(g):
-                                    print(raw_email)
+                                    print(
+                                        f"Error at UID {uid} in Folder {Foldername}:\n {error}\n\nGoing to the next Iteration.\n"
+                                        "--------------------------------------------------------"
+                                    )
+                            errorcounter += 1
+                            continue
+
                 except Exception as error:
                     with open(
                         f"export/{imap_server}/Error.log", "a", encoding="utf-8"


### PR DESCRIPTION
If the file path is too long, it will abort fetching the mails of the current folder and continue with the next folder.

Therefore I've added another try/catch "in each folder".

Additionally, I've fixed the root cause of my issue -> File path too long. I've hardened the exisitng sanity check, that only checks the file name for <250 char. I included the complete file path to this check. 
